### PR TITLE
changes for parsnip version 1.0.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ URL: https://hsbadr.github.io/additive/,
 BugReports: https://github.com/hsbadr/additive/issues
 Depends:
     mgcv (>= 1.8-40),
-    parsnip (>= 0.2.1),
+    parsnip (>= 1.0.0),
     R (>= 4.1.0)
 Imports:
     dplyr,

--- a/R/additive.R
+++ b/R/additive.R
@@ -297,7 +297,7 @@ update.additive <-
     } else {
       args <- parsnip::update_main_parameters(args, parameters)
 
-      eng_args <- parsnip::update_engine_parameters(object$eng_args, ...)
+      eng_args <- parsnip::update_engine_parameters(object$eng_args, fresh = fresh, ...)
 
       if (fresh) {
         object$args <- args


### PR DESCRIPTION
The new version of parsnip adds a `fresh` argument to `parsnip::update_engine_parameters()`. This PR passes the argument from your `update()` method to the parsnip function. 